### PR TITLE
[BUGFIX] Allow empty line as end of assignment

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -391,6 +391,7 @@ class Parser implements ParserInterface
                 $state->next(2);
                 break;
             case TokenInterface::TYPE_WHITESPACE:
+            case TokenInterface::TYPE_EMPTY_LINE:
                 $state->statements()->append($this->builder->op()->assignment(
                     $state->context(),
                     $this->builder->scalar(''),
@@ -452,7 +453,7 @@ class Parser implements ParserInterface
      */
     private function parseDeletion(ParserState $state): void
     {
-        $allowedTypesInDeletion = [TokenInterface::TYPE_WHITESPACE, TokenInterface::TYPE_COMMENT_ONELINE];
+        $allowedTypesInDeletion = [TokenInterface::TYPE_WHITESPACE, TokenInterface::TYPE_EMPTY_LINE, TokenInterface::TYPE_COMMENT_ONELINE];
 
         if (!in_array($state->token(2)->getType(), $allowedTypesInDeletion, true)) {
             throw new ParseError(


### PR DESCRIPTION
Fixes exception "Unexpected token = in" in parser with empty assignments followed by a empty line

```
myownemptyconstant =

myotherconstant = 
```